### PR TITLE
feat: Add MapillaryClient to download images from a latitude and longitude

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,9 @@ geopandas
 jupyterlab
 mapclassify
 matplotlib
+mapillary
+python-dotenv
+requests
 notebook
 numpy
 shapely

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,3 @@
+from dotenv import load_dotenv
+
+load_dotenv()

--- a/src/mapillary_client.py
+++ b/src/mapillary_client.py
@@ -1,0 +1,68 @@
+from os import getenv, getcwd
+import logging
+from pathlib import Path
+from mapillary import interface as mly
+from requests import get, RequestException
+
+
+class MapillaryClient:
+    def __init__(self, access_token: str, log_level: int = logging.INFO, basepath: str = getcwd()) -> None:
+        self.access_token = access_token
+        mly.set_access_token(access_token)
+        self.log = logging.getLogger(self.__class__.__name__)
+        self.log.addHandler(logging.StreamHandler())
+        self.log.setLevel(log_level)
+        self.basepath = basepath
+
+    def get_images_from_coordinates(self, latitude: float, longitude: float) -> list[Path]:
+        self.log.info("%s.%s: %s, %s",
+                      self.__class__.__name__,
+                      self.get_images_from_coordinates.__name__,
+                      latitude,
+                      longitude)
+
+        images = mly.get_image_close_to(latitude, longitude, image_type="pano").to_dict()
+        image_ids = list(map(lambda img: img["properties"]["id"], images["features"]))
+
+        self.log.info("%s.%s: got %s images close to %s, %s",
+                      self.__class__.__name__,
+                      self.get_images_from_coordinates.__name__,
+                      len(image_ids),
+                      latitude,
+                      longitude)
+        self.log.debug(image_ids)
+
+        return list(map(lambda img: self.download_image(img), image_ids))
+
+    def download_image(self, image_id: int) -> Path:
+        self.log.info("%s.%s: %s",
+                      self.__class__.__name__,
+                      self.download_image.__name__,
+                      image_id)
+        filepath = Path(self.basepath, f"{image_id}.jpg")
+        image_url = mly.image_thumbnail(str(image_id), 2048)
+        self.log.debug("%s.%s: image url for %s is %s",
+                      self.__class__.__name__,
+                      self.download_image.__name__,
+                      image_id,
+                      image_url)
+
+        try:
+            image_content = get(image_url).content
+            with open(filepath, "wb") as image_file:
+                image_file.write(image_content)
+            self.log.debug("%s.%s: image %s downloaded to %s",
+                          self.__class__.__name__,
+                          self.download_image.__name__,
+                          image_id,
+                          filepath)
+        except RequestException as e:
+            self.log.error(e)
+
+        return filepath
+
+
+if __name__ == "__main__":
+    client = MapillaryClient(getenv("MAPILLARY_API_KEY"))
+    downloaded_images = client.get_images_from_coordinates(47.617663, -122.169819)
+    logging.info(downloaded_images)

--- a/src/mapillary_client.py
+++ b/src/mapillary_client.py
@@ -1,5 +1,6 @@
 from os import getenv, getcwd
 import logging
+from multiprocessing import Pool
 from pathlib import Path
 from mapillary import interface as mly
 from requests import get, RequestException
@@ -32,9 +33,11 @@ class MapillaryClient:
                       longitude)
         self.log.debug(image_ids)
 
-        return list(map(lambda img: self.download_image(img), image_ids))
+        with Pool() as pool:
+            return pool.map(self.download_image, image_ids)
 
     def download_image(self, image_id: int) -> Path:
+        mly.set_access_token(self.access_token)
         self.log.info("%s.%s: %s",
                       self.__class__.__name__,
                       self.download_image.__name__,


### PR DESCRIPTION
# Changes
Add a `MapillaryClient` to call the Mapillary Python SDK to get some images from a latitude or longitude, by following these steps:

1. Get some GeoJSON data of images near a latitude or longitude. Filter for only panoramic images.
2. Get the Mapillary image id for each image from the GeoJSON
3. Get the mapillary image url from the image id
4. Download the image to a specified path from the url

Steps 3 and 4 execute concurrently through Python `multiprocessing`.

# Testing
Running `mapillary_client.py`'s dunder method, which does the steps above for a selected longitude and latitude, succeeds in downloading images.