### PR TITLE
Improve/fix make create_environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 #################################################################################
 
 ## Install Python Dependencies
-requirements: test_environment
+requirements: 
 	$(PYTHON_INTERPRETER) -m pip install -U pip setuptools wheel
 	$(PYTHON_INTERPRETER) -m pip install -r requirements.txt
 
@@ -59,10 +59,6 @@ else
 	@bash -c "source `which virtualenvwrapper.sh`;mkvirtualenv $(PROJECT_NAME) --python=$(PYTHON_INTERPRETER)"
 	@echo ">>> New virtualenv created. Activate with:\nworkon $(PROJECT_NAME)"
 endif
-
-## Test python environment is setup correctly
-test_environment:
-	$(PYTHON_INTERPRETER) test_environment.py
 
 #################################################################################
 # PROJECT RULES                                                                 #

--- a/Makefile
+++ b/Makefile
@@ -53,11 +53,8 @@ else
 endif
 		@echo ">>> New conda env created. Activate with:\nsource activate $(PROJECT_NAME)"
 else
-	$(PYTHON_INTERPRETER) -m pip install -q virtualenv virtualenvwrapper
-	@echo ">>> Installing virtualenvwrapper if not already installed.\nMake sure the following lines are in shell startup file\n\
-	export WORKON_HOME=$$HOME/.virtualenvs\nexport PROJECT_HOME=$$HOME/Devel\nsource /usr/local/bin/virtualenvwrapper.sh\n"
-	@bash -c "source `which virtualenvwrapper.sh`;mkvirtualenv $(PROJECT_NAME) --python=$(PYTHON_INTERPRETER)"
-	@echo ">>> New virtualenv created. Activate with:\nworkon $(PROJECT_NAME)"
+	$(PYTHON_INTERPRETER) -m venv .venv
+	@echo ">>> New virtual environment created. Activate with:\nsource .venv/bin/activate"
 endif
 
 #################################################################################

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ If you are interested in joining the project, please check out [`CONTRIBUTING.md
 
 1. Create a Python virtual environment.
      - You can use the shortcut command `make create_environment`.
+     - The log will tell you how to activate the environment. Do so with: `source .venv/bin/activate`
 2. Install requirements.
     ```bash
     pip install -r requirements.txt


### PR DESCRIPTION
Closes #19 

This fixes two things:

1. Uses `venv` in `make create_environment` instead of virtualenvwrapper to simplify the setup process. 

2. Removes a vestigial `test_environment` script reference. I had simplified things previously but accidentally left this in.