### PR TITLE
-e flag when pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you are interested in joining the project, please check out [`CONTRIBUTING.md
      - The log will tell you how to activate the environment. Do so with: `source .venv/bin/activate`
 2. Install requirements.
     ```bash
-    pip install .
+    pip install -e .
     ```
     - You can use the shortcut command `make requirements` to do the same thing.
 3. Put your raw OpenStreetMaps road vector data in `data/raw`.


### PR DESCRIPTION
minor change via @jayqi 
> In case you’ve followed the current version of the README you should install our code with `pip install -e .` instead of `pip install .` as it currently says. I’ve been meaning to open a PR to fix that You need the `-e` to get it to reflect any changes you make.