### PR TITLE
fix: Use stamina to retry images, add any caught exceptions to related GeoDataFrame fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ dependencies = [
   "tqdm",
   "python-dotenv", 
   "scikit-image", 
-  "opencv-python"
+  "opencv-python",
+  "stamina"
 ]
 
 ## TOOLS ##

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "python-dotenv", 
   "scikit-image", 
   "opencv-python",
-  "stamina"
+  "stamina",
 ]
 
 ## TOOLS ##

--- a/src/download_images.py
+++ b/src/download_images.py
@@ -7,9 +7,10 @@ import geopandas as gpd
 from geopy.distance import ELLIPSOIDS, distance
 import numpy as np
 from pandas import Series
-from requests import Session
-from requests.adapters import HTTPAdapter
-from requests.exceptions import HTTPError, RetryError
+import requests
+from requests.exceptions import HTTPError
+from stamina import retry
+from tenacity import RetryError
 from tqdm.contrib.concurrent import thread_map
 from typer import Argument, Option, Typer
 
@@ -30,13 +31,9 @@ class Mapillary:
         self.access_token = access_token
         self.basepath = basepath
         self.basepath.mkdir(parents=True, exist_ok=True)
-        self.client = Session()
-        self.client.mount(
-            "https://",
-            HTTPAdapter(max_retries=3),
-        )
         self.downloaded_images = set()
 
+    @retry(on=HTTPError, attempts=3)
     def get_image_from_coordinates(self, latitude: int, longitude: int) -> dict:
         log.debug("Get Image From Coordinates: %s, %s", latitude, longitude)
         results = {
@@ -47,20 +44,16 @@ class Mapillary:
             "image_path": None,
         }
 
-        try:
-            response = self.client.get(
-                self.url,
-                params={
-                    "access_token": self.access_token,
-                    "fields": "id,thumb_original_url,geometry",
-                    "is_pano": "true",
-                    "bbox": self._bounds(latitude, longitude),
-                },
-            )
-            response.raise_for_status()
-        except HTTPError or RetryError as e:
-            log.error(e)
-            return results
+        response = requests.get(
+            self.url,
+            params={
+                "access_token": self.access_token,
+                "fields": "id,thumb_original_url,geometry",
+                "is_pano": "true",
+                "bbox": self._bounds(latitude, longitude),
+            },
+        )
+        response.raise_for_status()
 
         images = response.json()["data"]
         log.debug("Successfully Retrieved Image Data: %s", images)
@@ -94,7 +87,10 @@ class Mapillary:
         results["image_lon"] = image["geometry"]["coordinates"][0]
         results["residual"] = closest_distance.m
         image_url = image["thumb_original_url"]
-        results["image_path"] = self._download_image(image_url, results["image_id"])
+        try:
+            results["image_path"] = self._download_image(image_url, results["image_id"])
+        except HTTPError or RetryError as e:
+            results["image_path"] = e.__class__.__name__
         self.downloaded_images.add(results["image_id"])
 
         return results
@@ -106,14 +102,11 @@ class Mapillary:
         top = latitude + 10 / 111_111
         return f"{left},{bottom},{right},{top}"
 
+    @retry(on=HTTPError, attempts=3)
     def _download_image(self, image_url, image_id) -> Optional[Path]:
         log.debug("Downloading Image: %s", image_id)
-        try:
-            response = self.client.get(image_url, stream=True)
-            response.raise_for_status()
-        except HTTPError or RetryError as e:
-            log.error(e)
-            return None
+        response = requests.get(image_url, stream=True)
+        response.raise_for_status()
         image_content = response.content
         log.debug("Successfully Retrieved Image: %s", image_id)
         image_path = Path(self.basepath, f"{image_id}.jpeg")
@@ -144,24 +137,32 @@ def main(
 
     mapillary = Mapillary(getenv("MAPILLARY_CLIENT_TOKEN"), images_path)
     gdf = gpd.read_file(points_file)
+    gdf["image_id"] = Series()
     gdf["image_lat"] = Series()
     gdf["image_lon"] = Series()
     gdf["residual"] = Series()
-    gdf["image_id"] = Series()
     gdf["image_path"] = Series()
 
     def download_image_for_gdf_row(row: int):
         latitude = gdf.at[row, "geometry"].y
         longitude = gdf.at[row, "geometry"].x
-        results = mapillary.get_image_from_coordinates(latitude, longitude)
-        gdf.at[row, "image_lat"] = results["image_lat"]
-        gdf.at[row, "image_lon"] = results["image_lon"]
-        gdf.at[row, "residual"] = results["residual"]
-        gdf.at[row, "image_id"] = results["image_id"]
-        gdf.at[row, "image_path"] = str(results["image_path"])
+        try:
+            results = mapillary.get_image_from_coordinates(latitude, longitude)
+            gdf.at[row, "image_lat"] = results["image_lat"]
+            gdf.at[row, "image_lon"] = results["image_lon"]
+            gdf.at[row, "residual"] = results["residual"]
+            gdf.at[row, "image_id"] = results["image_id"]
+            gdf.at[row, "image_path"] = str(results["image_path"])
+        except HTTPError or RetryError as e:
+            log.error(e)
+            gdf.at[row, "image_id"] = e.__class__.__name__
 
-    log.info("Downloading %s Images...", len(gdf))
-    thread_map(download_image_for_gdf_row, range(len(gdf)))
+    thread_map(
+        download_image_for_gdf_row,
+        range(len(gdf)),
+        desc=f"Downloading {len(gdf)} Images",
+        unit="images",
+    )
     log.info(gdf.head(20))
 
     gdf.to_file(

--- a/src/download_images.py
+++ b/src/download_images.py
@@ -42,7 +42,7 @@ class Mapillary:
             "residual": None,
             "image_id": None,
             "image_path": None,
-            "error": None
+            "error": None,
         }
 
         response = requests.get(


### PR DESCRIPTION
# Changes
* Addresses #24 
* Add `stamina` to handle retries when encountering `HTTPError` during API calls (most commonly getting a 400/Query Timeout from the Mapillary API)
* Catch any exceptions during API calls and put the exception class name inside the GeoDataFrame fields
* Add descriptions and units to `tqdm`

# Testing
* Retries and Exceptions in DataFrames worked on `Three_Rivers_Michigan_USA_points.gpkg`
* `make lint` succeeded
* `HTTPError` during image download:
```
       osm_id                    geometry          image_id  image_lat  image_lon  residual image_path
0    17967640  POINT (-85.65161 41.95364)              None       None       None      None       None
1    17967640  POINT (-85.65155 41.95379)              None       None       None      None       None
2    17967640  POINT (-85.65149 41.95394)              None       None       None      None       None
3    17967640  POINT (-85.65142 41.95408)              None       None       None      None       None
4    17964573  POINT (-85.65606 41.94811)              None       None       None      None       None
5    17964573  POINT (-85.65606 41.94826)              None       None       None      None       None
6    17964573  POINT (-85.65606 41.94841)              None       None       None      None       None
7    17964573  POINT (-85.65606 41.94856)              None       None       None      None       None
8    17964573  POINT (-85.65606 41.94871)              None       None       None      None       None
9    17964573  POINT (-85.65605 41.94886)              None       None       None      None       None
10  884351099  POINT (-85.65574 41.93250)  3957774314329497  41.932469 -85.655706  4.265796  HTTPError
11  884351099  POINT (-85.65573 41.93236)  1733045483547563  41.932364  -85.65575  1.286087  HTTPError
12  884351099  POINT (-85.65573 41.93223)   332637408194005  41.932222 -85.655753  2.171761  HTTPError
13  884351099  POINT (-85.65572 41.93210)   286705766499315  41.932114 -85.655742  2.845551  HTTPError
14  884351099  POINT (-85.65570 41.93196)   374581513941969  41.931956 -85.655714  1.675487  HTTPError
15  884351099  POINT (-85.65569 41.93183)   171334271569259  41.931847   -85.6557  2.082193  HTTPError
16  884351099  POINT (-85.65568 41.93170)  1140825166330088  41.931667 -85.655689  3.501513  HTTPError
17  884351099  POINT (-85.65567 41.93156)   232278071989214  41.931542 -85.655686  2.684181  HTTPError
18  884351099  POINT (-85.65567 41.93143)   473065397311618  41.931411 -85.655683  2.260846  HTTPError
19  884351099  POINT (-85.65567 41.93130)   184371856876241  41.931275 -85.655681  2.435379  HTTPError
```
* `HTTPError` during Mapillary API call:
```
       osm_id                    geometry   image_id image_lat image_lon residual image_path
0    17967640  POINT (-85.65161 41.95364)  HTTPError       NaN       NaN      NaN        NaN
1    17967640  POINT (-85.65155 41.95379)  HTTPError       NaN       NaN      NaN        NaN
2    17967640  POINT (-85.65149 41.95394)  HTTPError       NaN       NaN      NaN        NaN
3    17967640  POINT (-85.65142 41.95408)  HTTPError       NaN       NaN      NaN        NaN
4    17964573  POINT (-85.65606 41.94811)  HTTPError       NaN       NaN      NaN        NaN
5    17964573  POINT (-85.65606 41.94826)  HTTPError       NaN       NaN      NaN        NaN
6    17964573  POINT (-85.65606 41.94841)  HTTPError       NaN       NaN      NaN        NaN
7    17964573  POINT (-85.65606 41.94856)  HTTPError       NaN       NaN      NaN        NaN
8    17964573  POINT (-85.65606 41.94871)  HTTPError       NaN       NaN      NaN        NaN
9    17964573  POINT (-85.65605 41.94886)  HTTPError       NaN       NaN      NaN        NaN
10  884351099  POINT (-85.65574 41.93250)  HTTPError       NaN       NaN      NaN        NaN
11  884351099  POINT (-85.65573 41.93236)  HTTPError       NaN       NaN      NaN        NaN
12  884351099  POINT (-85.65573 41.93223)  HTTPError       NaN       NaN      NaN        NaN
13  884351099  POINT (-85.65572 41.93210)  HTTPError       NaN       NaN      NaN        NaN
14  884351099  POINT (-85.65570 41.93196)  HTTPError       NaN       NaN      NaN        NaN
15  884351099  POINT (-85.65569 41.93183)  HTTPError       NaN       NaN      NaN        NaN
16  884351099  POINT (-85.65568 41.93170)  HTTPError       NaN       NaN      NaN        NaN
17  884351099  POINT (-85.65567 41.93156)  HTTPError       NaN       NaN      NaN        NaN
18  884351099  POINT (-85.65567 41.93143)  HTTPError       NaN       NaN      NaN        NaN
19  884351099  POINT (-85.65567 41.93130)  HTTPError       NaN       NaN      NaN        NaN
```
