### PR TITLE
Scaffolding for unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,3 +32,32 @@ jobs:
       - name: Lint package
         run: |
           make lint
+
+  tests:
+    name: Tests (${{ matrix.os }}, Python ${{ matrix.python-version }})
+    needs: code-quality
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.11"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+
+      - name: Run tests
+        run: |
+          make test

--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,9 @@ endif
 #################################################################################
 
 ## Install Python Dependencies
-requirements: 
+requirements:
 	$(PYTHON_INTERPRETER) -m pip install -U pip setuptools wheel
 	$(PYTHON_INTERPRETER) -m pip install -e .
-
-## Make Dataset
-data: requirements
-	$(PYTHON_INTERPRETER) src/data/make_dataset.py data/raw data/processed
 
 ## Delete all compiled Python files
 clean:
@@ -34,13 +30,17 @@ clean:
 
 ## Format using ruff
 format:
-	ruff format src
-	ruff check src --fix
+	ruff format src tests
+	ruff check src tests --fix
 
 ## Lint using ruff
 lint:
-	ruff format --check src
-	ruff check src
+	ruff format --check src tests
+	ruff check src tests
+
+## Run tests
+test:
+	pytest -vv
 
 ## Set up python interpreter environment
 create_environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,18 +26,20 @@ dependencies = [
   "pandas",
   "geopy",
   "tqdm",
-  "python-dotenv", 
-  "scikit-image", 
+  "python-dotenv",
+  "scikit-image",
   "opencv-python",
   "stamina",
   "pillow",
   "loguru",
+  "pytest",
+  "pytest-cov",
 ]
 
 ## TOOLS ##
 
 [tool.ruff]
-src = ["src/**/*.py"]
+src = ["src/**/*.py", "tests/**/*.py"]
 
 [tool.ruff.lint]
 select = [
@@ -50,3 +52,11 @@ unfixable = ["F"]
 [tool.ruff.lint.isort]
 known-first-party = ["src"]
 force-sort-within-sections = true
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "--cov=src --cov-report=term --cov-report=html --cov-report=xml"
+testpaths = ["tests"]
+
+[tool.coverage.run]
+source = ["src"]

--- a/src/assign_gvi_to_points.py
+++ b/src/assign_gvi_to_points.py
@@ -69,7 +69,7 @@ def main(
         ),
     ],
 ):
-    """
+    """Calculate Green View Index (GVI) scores for a dataset of street-level images.
 
     Args:
             image_directory: directory path for folder holding Mapillary images

--- a/src/create_points.py
+++ b/src/create_points.py
@@ -133,6 +133,7 @@ def main(
         ),
     ] = False,
 ):
+    """Create a dataset of interpolated points along OpenStreetMap roads."""
     gdf = gpd.read_file(in_file)
     gdf = filter_by_highway_type(gdf)
     if drop_null:

--- a/tests/test_assign_gvi_to_points.py
+++ b/tests/test_assign_gvi_to_points.py
@@ -1,0 +1,16 @@
+from typer.testing import CliRunner
+
+from src.assign_gvi_to_points import app
+
+runner = CliRunner(mix_stderr=False)
+
+
+def test_help():
+    """Test the CLI with --help flag."""
+    result = runner.invoke(app, ["--help"])
+    print(result.output)
+    assert result.exit_code == 0
+    assert (
+        "Calculate Green View Index (GVI) scores for a dataset of street-level images."
+        in result.output
+    )

--- a/tests/test_assign_images.py
+++ b/tests/test_assign_images.py
@@ -1,0 +1,13 @@
+from typer.testing import CliRunner
+
+from src.assign_images import app
+
+runner = CliRunner(mix_stderr=False)
+
+
+def test_help():
+    """Test the CLI with --help flag."""
+    result = runner.invoke(app, ["--help"])
+    print(result.output)
+    assert result.exit_code == 0
+    assert "Assigns Images to Points" in result.output

--- a/tests/test_create_points.py
+++ b/tests/test_create_points.py
@@ -1,0 +1,16 @@
+from typer.testing import CliRunner
+
+from src.create_points import app
+
+runner = CliRunner(mix_stderr=False)
+
+
+def test_help():
+    """Test the CLI with --help flag."""
+    result = runner.invoke(app, ["--help"])
+    print(result.output)
+    assert result.exit_code == 0
+    assert (
+        "Create a dataset of interpolated points along OpenStreetMap roads."
+        in result.output
+    )


### PR DESCRIPTION
This PR adds scaffolding for unit tests.

- Uses pytest for testing.
- Uses pytest-cov for generating coverage reports. 
   - We can consider adding coverage reporting to CI (e.g., via Codecov) later if we'd like. For now, this generates coverage information in your terminal when you run the tests, and some coverage report artifacts you can inspect. 
- Adds tests to CI. 
    - Currently the test matrix is [Ubuntu, macOS] x [Python 3.11]. We can add Windows and other Python versions now or later if we'd like. 
- Adds a test directory with some scaffold test modules for the main steps in our pipeline. 
    - Currently these only contain tests that the `--help` flag works or each step's CLI interface. Nothing of substance is tested yet.

A start to addressing #49. 