### PR TITLE
fix: Stamina Retry on all HTTPError and RequestException

### DIFF
--- a/src/images/mapillary.py
+++ b/src/images/mapillary.py
@@ -133,7 +133,7 @@ class Mapillary(ImageSource):
         top = latitude + self.max_distance / 111_111
         return f"{left},{bottom},{right},{top}"
 
-    @retry(on=HTTPError, attempts=3)
+    @retry(on=(HTTPError, RequestException), attempts=3)
     def _download_image(self, image_url: str, image_id: str) -> Optional[Path]:
         """
         Downloads an Image from a URL to images_path/image_id.jpeg

--- a/src/images/mapillary.py
+++ b/src/images/mapillary.py
@@ -4,10 +4,11 @@ from typing import Optional
 from geopy.distance import ELLIPSOIDS, distance
 from loguru import logger as log
 import requests
-from requests import HTTPError
+from requests import RequestException
 from stamina import retry
 from tenacity import RetryError
 from typing_extensions import override
+from urllib3.exceptions import HTTPError
 
 from src.images.image_source import ImageSource
 
@@ -35,7 +36,7 @@ class Mapillary(ImageSource):
         self.assigned_images = set()
 
     @override
-    @retry(on=HTTPError, attempts=3)
+    @retry(on=(HTTPError, RequestException), attempts=3)
     def get_image_from_coordinates(self, latitude: float, longitude: float) -> dict:
         """
         Gets an image for a set of coordinates


### PR DESCRIPTION
# Description
An attempt to avoid stopping execution if a ChunkedEncodingError is encountered in #47 
# Changes
* Change the stamina retry condition to be `urllib3.exceptions.HTTPError` and `requests.RequestException`
* I don't think there are any issues if we retry on all `HTTPError` or `RequestException`, but there may be an edge case in which we don't want to retry an API call or image download that I haven't though of

# Testing
* `python -m src.assign_images data/interim/Three_Rivers_Michigan_USA_points.gpkg MAPILLARY data/raw/mapillary/`downloaded many images successfully, and stamina retried in the logs