### PR TITLE
docs: add link to Conventional Commits spec

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,10 @@ ruff format src
 ruff check src --fix
 ```
 
+### Commits
+
+Please follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification when creating your commit messages.
+
 ## For maintainers
 
 ### Checkout a PR branch from a fork


### PR DESCRIPTION
> The [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification is a lightweight convention on top of commit messages. It provides an easy set of rules for creating an explicit commit history

based on @dragonejt's usage and note in https://github.com/AmericanRedCross/street-view-green-view/pull/74#issuecomment-2297655785